### PR TITLE
Replace dead I2P-Bote link with working one

### DIFF
--- a/index.html
+++ b/index.html
@@ -1324,8 +1324,8 @@
 						<p><img src="img/tools/I2P.png" alt="I2P-Bote" align="right" style="margin-left:5px;">I2P-Bote is a fully decentralized and distributed email system. It supports different identities and does not expose email headers. Currently (2015), it is still
 							in beta version and can be accessed via its web application interface or IMAP and SMTP. All bote-mails are transparently end-to-end encrypted and, optionally, signed by the sender's private key.</p>
 						<p>
-							<a href="http://i2pbote.i2p.us/">
-								<button type="button" class="btn btn-info">Website: i2pbote.i2p.us</button>
+							<a href="http://bote.i2p.xyz/">
+								<button type="button" class="btn btn-info">Website: bote.i2p.xyz</button>
 							</a>
 						</p>
 						<p>OS: Windows, Mac, Linux, Android, F-Droid.</p>

--- a/index.html
+++ b/index.html
@@ -1324,8 +1324,8 @@
 						<p><img src="img/tools/I2P.png" alt="I2P-Bote" align="right" style="margin-left:5px;">I2P-Bote is a fully decentralized and distributed email system. It supports different identities and does not expose email headers. Currently (2015), it is still
 							in beta version and can be accessed via its web application interface or IMAP and SMTP. All bote-mails are transparently end-to-end encrypted and, optionally, signed by the sender's private key.</p>
 						<p>
-							<a href="http://bote.i2p.xyz/">
-								<button type="button" class="btn btn-info">Website: bote.i2p.xyz</button>
+							<a href="https://i2pbote.xyz/">
+								<button type="button" class="btn btn-info">Website: i2pbote.xyz</button>
 							</a>
 						</p>
 						<p>OS: Windows, Mac, Linux, Android, F-Droid.</p>


### PR DESCRIPTION
https://github.com/privacytoolsIO/privacytools.io/pull/91

> i2pbote.i2p website is down and old maintainer is missing for a year, new maintainer @str4d have set up bote.i2p webpage.
> 
> Also, i2p.us seems to be down, replace it with i2p.xyz in-proxy.

@str4d

> I've just set up https://i2pbote.xyz/ which you could use instead :smile: