### PR TITLE
Replace CloudNS with DNS.WATCH

### DIFF
--- a/index.html
+++ b/index.html
@@ -2122,8 +2122,7 @@
 						<h3 class="panel-title">DNS.WATCH - Service</h3>
 					</div>
 					<div class="panel-body">
-						<p>A german based DNS provider. Features: IPv6 support, logless, support DNSSEC authentication, free, uncensored and neutral.
-							or logging.</p>
+						<p>A german based DNS provider. Features: IPv6 support, logless, DNSSEC authentication support. Free, uncensored and neutral.</p>
 						<p>
 							<a href="https://dns.watch/">
 								<button type="button" class="btn btn-success">Website: dns.watch</button>

--- a/index.html
+++ b/index.html
@@ -2119,14 +2119,14 @@
 			<div class="col-sm-4">
 				<div class="panel panel-success">
 					<div class="panel-heading">
-						<h3 class="panel-title">CloudNS - Service</h3>
+						<h3 class="panel-title">DNS.WATCH - Service</h3>
 					</div>
 					<div class="panel-body">
-						<p>An australian based security focused DNS provider. Features: DNSCrypt Support to provide confidentially and message integrity, complete trust validation of DNSSEC enabled names, namecoin resolution of .bit domain names and no domain manipulation
+						<p>A german based DNS provider. Features: IPv6 support, logless, DNSSEC, free, uncensored and neutral.
 							or logging.</p>
 						<p>
-							<a href="https://cloudns.com.au/">
-								<button type="button" class="btn btn-success">Website: cloudns.com.au</button>
+							<a href="https://dns.watch/">
+								<button type="button" class="btn btn-success">Website: dns.watch</button>
 							</a>
 						</p>
 						<p>OS: Cross-platform.</p>

--- a/index.html
+++ b/index.html
@@ -2122,7 +2122,7 @@
 						<h3 class="panel-title">DNS.WATCH - Service</h3>
 					</div>
 					<div class="panel-body">
-						<p>A german based DNS provider. Features: IPv6 support, logless, DNSSEC, free, uncensored and neutral.
+						<p>A german based DNS provider. Features: IPv6 support, logless, support DNSSEC authentication, free, uncensored and neutral.
 							or logging.</p>
 						<p>
 							<a href="https://dns.watch/">


### PR DESCRIPTION
CloudNS is not working anymore, so here's a great alternative.

PR following this issue : https://github.com/privacytools-io/privacytools.io/issues/16